### PR TITLE
検索インデックスに登録

### DIFF
--- a/initialize_script.sh
+++ b/initialize_script.sh
@@ -7,3 +7,5 @@ docker compose run --rm web uv run manage.py init_index
 sleep 4s
 # 検索ログのインポート
 docker compose run --rm web uv run manage.py import_search_log search_log.csv
+sleep 4s
+docker compose run --rm web uv run manage.py register_searchlog_to_index

--- a/initialize_script.sh
+++ b/initialize_script.sh
@@ -4,5 +4,6 @@ docker compose run --rm web uv run manage.py register_fake_blog_model --num 100
 # インデックス作成に時間がかかるため、4秒待つ
 sleep 4s
 docker compose run --rm web uv run manage.py init_index
+sleep 4s
 # 検索ログのインポート
 docker compose run --rm web uv run manage.py import_search_log search_log.csv

--- a/web/blog/templates/blog_list.html
+++ b/web/blog/templates/blog_list.html
@@ -143,18 +143,16 @@
     </div>
 
     <div class="time-based-results">
-        <h3>同じ時間帯の検索ワード:</h3>
+        <h3>一緒に検索されたワード:</h3>
         <ul>
             {% if time_based_results %}
                 {% for result in time_based_results %}
                     <li class="time-based-result-item">
-                        <p>時間: {{ result.timestamp }}</p>
-                        <p>検索ワード: {{ result.word }}</p>
-                        <p>出現回数: {{ result.count }}</p>
+                        <p>{{ result.word }} ({{ result.count }})</p>
                     </li>
                 {% endfor %}
             {% else %}
-                <p>同じ時間帯の検索ワードはありません。</p>
+                <p>一緒に検索されたワードはありません。</p>
             {% endif %}
         </ul>
     </div>

--- a/web/blog/templates/blog_list.html
+++ b/web/blog/templates/blog_list.html
@@ -141,5 +141,22 @@
             {% endif %}
         </ul>
     </div>
+
+    <div class="time-based-results">
+        <h3>同じ時間帯の検索ワード:</h3>
+        <ul>
+            {% if time_based_results %}
+                {% for result in time_based_results %}
+                    <li class="time-based-result-item">
+                        <p>時間: {{ result.timestamp }}</p>
+                        <p>検索ワード: {{ result.word }}</p>
+                        <p>出現回数: {{ result.count }}</p>
+                    </li>
+                {% endfor %}
+            {% else %}
+                <p>同じ時間帯の検索ワードはありません。</p>
+            {% endif %}
+        </ul>
+    </div>
 </body>
 </html>

--- a/web/search/documents.py
+++ b/web/search/documents.py
@@ -112,10 +112,8 @@ class SearchLogDocument(Document):
                         "filter": [
                             "sudachi_baseform",
                             "sudachi_part_of_speech",
-                            "cjk_width",
                             "lowercase",
                             "sudachi_readingform",
-                            "sudachi_normalizedform",
                         ],
                     }
                 }

--- a/web/search/documents.py
+++ b/web/search/documents.py
@@ -89,3 +89,35 @@ class NoOrderRelatedSearchWordLogDocument(Document):
 
     class Meta:
         name = "no_order_related_search_word_log"
+
+
+class SearchLogDocument(Document):
+    """検索ログを保存するためのドキュメント"""
+
+    id = Text()
+    user_id = Keyword()
+    search_query = Keyword()
+    searched_at = Integer()  # UNIX時間（エポック秒）
+
+    class Meta:
+        name = "search_log"
+        settings = {
+            "analysis": {
+                "analyzer": {
+                    "sudachi_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "sudachi_tokenizer",
+                        "mode": "search",
+                        "char_filter": ["icu_normalizer"],
+                        "filter": [
+                            "sudachi_baseform",
+                            "sudachi_part_of_speech",
+                            "cjk_width",
+                            "lowercase",
+                            "sudachi_readingform",
+                            "sudachi_normalizedform",
+                        ],
+                    }
+                }
+            }
+        }

--- a/web/search/management/commands/register_searchlog_to_index.py
+++ b/web/search/management/commands/register_searchlog_to_index.py
@@ -1,0 +1,32 @@
+import uuid
+from django.core.management.base import BaseCommand
+from search.models import SearchLog
+from search.search_log import make_client
+from search.documents import SearchLogDocument
+
+
+class Command(BaseCommand):
+    help = "SearchLogモデルの内容をOpenSearchの検索インデックスに登録します"
+
+    def handle(self, *args, **options):
+        client = make_client()
+
+        # インデックスがなければ作成
+        if not client.indices.exists(index="search_log"):
+            SearchLogDocument.init(using=client, index="search_log")
+
+        logs = SearchLog.objects.all()
+        count = 0
+        for log in logs:
+            doc = SearchLogDocument(
+                id=str(uuid.uuid4()),
+                user_id=log.user_id,
+                search_query=log.search_query,
+                searched_at=log.searched_at,
+            )
+            doc.save(using=client, index="search_log")
+            count += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(f"{count}件の検索ログをOpenSearchに登録しました")
+        )


### PR DESCRIPTION
### **PR Type**
enhancement, other


___

### **Description**
- 新しいクラス`SearchLogDocument`を追加し、検索ログを保存するためのドキュメントを定義しました。
- カスタムアナライザー`sudachi_analyzer`を設定し、検索ログの分析を強化しました。
- Django管理コマンドを追加し、`SearchLog`モデルのデータをOpenSearchの検索インデックスに登録する機能を実装しました。
- インデックスが存在しない場合は自動的に作成されるようにしました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>documents.py</strong><dd><code>検索ログ用のドキュメントクラスを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/search/documents.py

<li>新しいクラス<code>SearchLogDocument</code>を追加。<br> <li> 検索ログを保存するためのドキュメントを定義。<br> <li> カスタムアナライザー<code>sudachi_analyzer</code>を設定。<br>


</details>


  </td>
  <td><a href="https://github.com/KJMAN678/django_opensearch/pull/3/files#diff-94e007d63ef87f4ff411a82aeb3dde38e67abac1cd029607e57121684d69998e">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>register_searchlog_to_index.py</strong><dd><code>検索ログをOpenSearchに登録するコマンドを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/search/management/commands/register_searchlog_to_index.py

<li>新しいDjango管理コマンドを追加。<br> <li> <code>SearchLog</code>モデルのデータをOpenSearchに登録。<br> <li> インデックスが存在しない場合は作成。<br>


</details>


  </td>
  <td><a href="https://github.com/KJMAN678/django_opensearch/pull/3/files#diff-2c21ab76769ba90456f44030b20e46b6e8a62ccb568bfe203f0cac660f1eab78">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

